### PR TITLE
Add client-side PDF ⇄ Word conversion UI and utilities

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - work
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for GitHub Pages
+        env:
+          VITE_BASE_PATH: /${{ github.event.repository.name }}/
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Markdown to PDF (React + TypeScript)
+
+A client-side React app that supports:
+
+- Markdown/text to PDF
+- PDF to Word (.docx)
+- Word (.docx) to PDF
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Deployment (GitHub Pages)
+
+This repository includes an Actions workflow at `.github/workflows/deploy-pages.yml`.
+
+### One-time setup
+
+1. Push this branch to GitHub.
+2. Open **Settings → Pages**.
+3. Set **Source** to **GitHub Actions**.
+
+### Deploy
+
+- Push to the `work` branch, or
+- Run **Deploy to GitHub Pages** manually from the **Actions** tab.
+
+The workflow will install dependencies, build with `VITE_BASE_PATH=/<repo-name>/`, upload `dist/`, and publish to GitHub Pages.
+
+## Notes on format fidelity
+
+Document conversion is handled fully client-side. The app preserves structure and content as much as browser-based conversion libraries allow. Highly complex layouts may require manual fine-tuning after conversion.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown to PDF Generator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "learninghub-markdown-pdf",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 5173",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "file-saver": "^2.0.5",
+    "jspdf": "^2.5.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0",
+    "docx": "^8.5.0",
+    "mammoth": "^1.8.0",
+    "pdfjs-dist": "^4.6.82"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import DocumentConverter from './components/DocumentConverter';
+import Editor from './components/Editor';
+import PdfGenerator from './components/PdfGenerator';
+import Preview from './components/Preview';
+import { useTheme } from './hooks/useTheme';
+
+const initialContent = `# Markdown to PDF\n\n## Quick Start\n- Type your content in the editor\n- Upload a .md file\n- Click **Generate PDF**\n\n\`\`\`ts\nconsole.log('Hello PDF!');\n\`\`\``;
+
+const App = () => {
+  const [content, setContent] = useState(initialContent);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <main className="app-shell">
+      <header className="app-header">
+        <h1>Text / Markdown to PDF</h1>
+        <button type="button" className="secondary-button" onClick={toggleTheme}>
+          {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+        </button>
+      </header>
+
+      <div className="layout-grid">
+        <Editor
+          content={content}
+          onContentChange={setContent}
+          errorMessage={errorMessage}
+          onError={setErrorMessage}
+        />
+        <Preview content={content} />
+      </div>
+
+      <footer className="app-footer">
+        <PdfGenerator
+          content={content}
+          onError={setErrorMessage}
+          loading={isGenerating}
+          setLoading={setIsGenerating}
+        />
+      </footer>
+
+      <DocumentConverter onError={setErrorMessage} />
+      {errorMessage && <p className="error-message global-error">{errorMessage}</p>}
+    </main>
+  );
+};
+
+export default App;

--- a/src/components/DocumentConverter.tsx
+++ b/src/components/DocumentConverter.tsx
@@ -1,0 +1,94 @@
+import { ChangeEvent, useRef, useState } from 'react';
+import { saveAs } from 'file-saver';
+import { convertPdfToWord, convertWordToPdf } from '../utils/documentConverters';
+
+interface DocumentConverterProps {
+  onError: (value: string | null) => void;
+}
+
+type ConversionMode = 'pdf-to-word' | 'word-to-pdf';
+
+const DocumentConverter = ({ onError }: DocumentConverterProps) => {
+  const [mode, setMode] = useState<ConversionMode>('pdf-to-word');
+  const [isConverting, setIsConverting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const acceptedInput = mode === 'pdf-to-word' ? '.pdf,application/pdf' : '.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+  const validateFile = (file: File) => {
+    if (mode === 'pdf-to-word') {
+      return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+    }
+
+    return (
+      file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+      file.name.toLowerCase().endsWith('.docx')
+    );
+  };
+
+  const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (!validateFile(file)) {
+      onError(mode === 'pdf-to-word' ? 'Please upload a valid PDF file.' : 'Please upload a valid DOCX file.');
+      return;
+    }
+
+    setIsConverting(true);
+    onError(null);
+
+    try {
+      const result = mode === 'pdf-to-word' ? await convertPdfToWord(file) : await convertWordToPdf(file);
+      saveAs(result.blob, result.filename);
+    } catch (error) {
+      onError('Conversion failed. Please verify the document and try again.');
+    } finally {
+      setIsConverting(false);
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <section className="panel converter-panel">
+      <h2>Document Converter</h2>
+      <p className="helper-text">Convert between PDF and Word formats while preserving content structure as much as possible.</p>
+
+      <div className="converter-controls">
+        <label>
+          <input
+            type="radio"
+            name="convert-mode"
+            checked={mode === 'pdf-to-word'}
+            onChange={() => setMode('pdf-to-word')}
+          />
+          PDF → Word (.docx)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="convert-mode"
+            checked={mode === 'word-to-pdf'}
+            onChange={() => setMode('word-to-pdf')}
+          />
+          Word (.docx) → PDF
+        </label>
+      </div>
+
+      <button
+        type="button"
+        className="primary-button"
+        disabled={isConverting}
+        onClick={() => inputRef.current?.click()}
+      >
+        {isConverting ? 'Converting...' : mode === 'pdf-to-word' ? 'Upload PDF and Convert' : 'Upload DOCX and Convert'}
+      </button>
+
+      <input ref={inputRef} type="file" accept={acceptedInput} onChange={handleFileSelect} hidden />
+    </section>
+  );
+};
+
+export default DocumentConverter;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,102 @@
+import { ChangeEvent, DragEvent, useRef, useState } from 'react';
+
+interface EditorProps {
+  content: string;
+  errorMessage: string | null;
+  onContentChange: (value: string) => void;
+  onError: (value: string | null) => void;
+}
+
+const ALLOWED_FILE_TYPES = ['text/plain', 'text/markdown'];
+const ALLOWED_EXTENSIONS = ['.txt', '.md', '.markdown'];
+
+const Editor = ({ content, errorMessage, onContentChange, onError }: EditorProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isValidFile = (file: File) => {
+    const hasAllowedMime = ALLOWED_FILE_TYPES.includes(file.type);
+    const hasAllowedExtension = ALLOWED_EXTENSIONS.some((ext) => file.name.toLowerCase().endsWith(ext));
+    return hasAllowedMime || hasAllowedExtension;
+  };
+
+  const processFile = (file: File) => {
+    if (!isValidFile(file)) {
+      onError('Invalid file type. Please upload a .md or .txt file.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const fileContent = event.target?.result;
+      if (typeof fileContent === 'string') {
+        onContentChange(fileContent);
+        onError(null);
+      }
+    };
+    reader.onerror = () => {
+      onError('Could not read file. Please try again.');
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      processFile(file);
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    const file = event.dataTransfer.files?.[0];
+    if (file) {
+      processFile(file);
+    }
+  };
+
+  return (
+    <section className="panel">
+      <h2>Editor</h2>
+      <button type="button" className="secondary-button" onClick={() => fileInputRef.current?.click()}>
+        Upload .md/.txt
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md,.markdown,.txt,text/markdown,text/plain"
+        onChange={handleFileChange}
+        hidden
+      />
+
+      <div
+        className={`drop-zone ${isDragging ? 'drag-active' : ''}`}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+      >
+        Drag and drop Markdown/text file here
+      </div>
+
+      <textarea
+        className="editor-textarea"
+        value={content}
+        onChange={(event) => {
+          onContentChange(event.target.value);
+          if (errorMessage) {
+            onError(null);
+          }
+        }}
+        placeholder="Type markdown here..."
+      />
+
+      {errorMessage && <p className="error-message">{errorMessage}</p>}
+    </section>
+  );
+};
+
+export default Editor;

--- a/src/components/PdfGenerator.tsx
+++ b/src/components/PdfGenerator.tsx
@@ -1,0 +1,39 @@
+import { saveAs } from 'file-saver';
+import { generatePdfFromMarkdown } from '../utils/markdownPdf';
+
+interface PdfGeneratorProps {
+  content: string;
+  onError: (value: string | null) => void;
+  loading: boolean;
+  setLoading: (value: boolean) => void;
+}
+
+const PdfGenerator = ({ content, onError, loading, setLoading }: PdfGeneratorProps) => {
+  const handleGeneratePdf = async () => {
+    if (!content.trim()) {
+      onError('Content is empty. Please enter text before generating a PDF.');
+      return;
+    }
+
+    setLoading(true);
+    onError(null);
+
+    try {
+      const pdfBlob = generatePdfFromMarkdown(content);
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      saveAs(pdfBlob, `document_${timestamp}.pdf`);
+    } catch (error) {
+      onError('PDF generation failed. Please review your content and try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button type="button" className="primary-button" onClick={handleGeneratePdf} disabled={loading}>
+      {loading ? 'Generating...' : 'Generate PDF'}
+    </button>
+  );
+};
+
+export default PdfGenerator;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,0 +1,21 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface PreviewProps {
+  content: string;
+}
+
+const Preview = ({ content }: PreviewProps) => (
+  <section className="panel preview-panel">
+    <h2>Live Preview</h2>
+    <article className="markdown-preview">
+      {content.trim() ? (
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      ) : (
+        <p className="placeholder">Preview appears here when you type or upload content.</p>
+      )}
+    </article>
+  </section>
+);
+
+export default Preview;

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const getInitialTheme = (): Theme => {
+  const storedTheme = window.localStorage.getItem('theme');
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.body.dataset.theme = theme;
+    window.localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((currentTheme) => (currentTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  return {
+    theme,
+    toggleTheme
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,183 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --text: #1d2230;
+  --panel: #ffffff;
+  --border: #d8dfeb;
+  --accent: #335dff;
+  --muted: #6a7388;
+  --danger: #cf2442;
+}
+
+body[data-theme='dark'] {
+  --bg: #131722;
+  --text: #eef2ff;
+  --panel: #1b2232;
+  --border: #36435f;
+  --accent: #7f9cff;
+  --muted: #9da9c7;
+  --danger: #ff7d95;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.25rem;
+}
+
+.app-header,
+.app-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+  min-height: 420px;
+}
+
+.editor-textarea {
+  width: 100%;
+  min-height: 260px;
+  margin-top: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: transparent;
+  color: var(--text);
+  resize: vertical;
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #fff;
+}
+
+.secondary-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.primary-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.drop-zone {
+  margin-top: 0.75rem;
+  border: 2px dashed var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.drag-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.markdown-preview {
+  max-height: 520px;
+  overflow: auto;
+}
+
+.markdown-preview pre {
+  background: rgba(55, 80, 150, 0.12);
+  padding: 0.6rem;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.markdown-preview table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.markdown-preview th,
+.markdown-preview td {
+  border: 1px solid var(--border);
+  padding: 0.4rem;
+}
+
+.error-message {
+  color: var(--danger);
+  font-size: 0.95rem;
+}
+
+.placeholder {
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-header,
+  .app-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+
+.converter-panel {
+  margin-top: 1rem;
+  min-height: auto;
+}
+
+.helper-text {
+  color: var(--muted);
+  margin-top: 0;
+}
+
+.converter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.converter-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.global-error {
+  margin-top: 1rem;
+}

--- a/src/types/file-saver.d.ts
+++ b/src/types/file-saver.d.ts
@@ -1,0 +1,3 @@
+declare module 'file-saver' {
+  export function saveAs(data: Blob | File | string, filename?: string): void;
+}

--- a/src/types/mammoth.d.ts
+++ b/src/types/mammoth.d.ts
@@ -1,0 +1,17 @@
+declare module 'mammoth' {
+  interface ConvertResult {
+    value: string;
+  }
+
+  interface InputLike {
+    arrayBuffer: ArrayBuffer;
+  }
+
+  function convertToHtml(input: InputLike): Promise<ConvertResult>;
+
+  const mammoth: {
+    convertToHtml: typeof convertToHtml;
+  };
+
+  export default mammoth;
+}

--- a/src/types/pdfjs-dist.d.ts
+++ b/src/types/pdfjs-dist.d.ts
@@ -1,0 +1,10 @@
+declare module 'pdfjs-dist' {
+  interface PdfDocumentProxy {
+    numPages: number;
+    getPage(pageNumber: number): Promise<{
+      getTextContent(): Promise<{ items: unknown[] }>;
+    }>;
+  }
+
+  export function getDocument(params: { data: ArrayBuffer }): { promise: Promise<PdfDocumentProxy> };
+}

--- a/src/utils/documentConverters.ts
+++ b/src/utils/documentConverters.ts
@@ -1,0 +1,68 @@
+import jsPDF from 'jspdf';
+import { Document, Packer, Paragraph, TextRun } from 'docx';
+import mammoth from 'mammoth';
+import { getDocument } from 'pdfjs-dist';
+
+const cleanText = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const getTimestamp = () => new Date().toISOString().replace(/[:.]/g, '-');
+
+const stripHtml = (html: string) => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  return doc.body.textContent ?? '';
+};
+
+export const convertPdfToWord = async (file: File): Promise<{ blob: Blob; filename: string }> => {
+  const arrayBuffer = await file.arrayBuffer();
+  const pdf = await getDocument({ data: arrayBuffer }).promise;
+  const paragraphs: Paragraph[] = [];
+
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+    const page = await pdf.getPage(pageNumber);
+    const content = await page.getTextContent();
+    const items = content.items as Array<{ str?: string }>;
+    const pageText = items
+      .map((item) => item.str ?? '')
+      .join(' ')
+      .split(/\s{2,}/)
+      .map(cleanText)
+      .filter(Boolean);
+
+    pageText.forEach((text) => {
+      paragraphs.push(new Paragraph({ children: [new TextRun(text)] }));
+    });
+
+    if (pageNumber < pdf.numPages) {
+      paragraphs.push(new Paragraph({ children: [new TextRun('')] }));
+    }
+  }
+
+  const document = new Document({
+    sections: [{ children: paragraphs.length ? paragraphs : [new Paragraph('')] }]
+  });
+
+  const blob = await Packer.toBlob(document);
+  return { blob, filename: `document_${getTimestamp()}.docx` };
+};
+
+export const convertWordToPdf = async (file: File): Promise<{ blob: Blob; filename: string }> => {
+  const arrayBuffer = await file.arrayBuffer();
+  const { value: html } = await mammoth.convertToHtml({ arrayBuffer });
+
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  const plainText = stripHtml(html);
+  const lines = doc.splitTextToSize(plainText, 180);
+  let y = 20;
+
+  lines.forEach((line: string) => {
+    if (y > 280) {
+      doc.addPage();
+      y = 20;
+    }
+    doc.text(line, 15, y);
+    y += 6;
+  });
+
+  return { blob: doc.output('blob'), filename: `document_${getTimestamp()}.pdf` };
+};

--- a/src/utils/markdownPdf.ts
+++ b/src/utils/markdownPdf.ts
@@ -1,0 +1,89 @@
+import jsPDF from 'jspdf';
+
+const splitAndWriteText = (
+  doc: jsPDF,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number
+): number => {
+  const lines = doc.splitTextToSize(text, maxWidth);
+  lines.forEach((line: string) => {
+    if (y > 280) {
+      doc.addPage();
+      y = 20;
+    }
+    doc.text(line, x, y);
+    y += lineHeight;
+  });
+  return y;
+};
+
+export const generatePdfFromMarkdown = (content: string): Blob => {
+  const doc = new jsPDF({
+    unit: 'mm',
+    format: 'a4'
+  });
+
+  const lines = content.split('\n');
+  let y = 20;
+
+  lines.forEach((rawLine) => {
+    const line = rawLine.trimEnd();
+
+    if (!line.trim()) {
+      y += 4;
+      return;
+    }
+
+    if (line.startsWith('### ')) {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(14);
+      y = splitAndWriteText(doc, line.replace(/^###\s/, ''), 15, y, 180, 7);
+      y += 2;
+      return;
+    }
+
+    if (line.startsWith('## ')) {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(16);
+      y = splitAndWriteText(doc, line.replace(/^##\s/, ''), 15, y, 180, 8);
+      y += 2;
+      return;
+    }
+
+    if (line.startsWith('# ')) {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(18);
+      y = splitAndWriteText(doc, line.replace(/^#\s/, ''), 15, y, 180, 9);
+      y += 3;
+      return;
+    }
+
+    if (line.startsWith('```')) {
+      doc.setFont('courier', 'normal');
+      doc.setFontSize(10);
+      y = splitAndWriteText(doc, line, 20, y, 170, 5);
+      return;
+    }
+
+    if (line.startsWith('- ') || /^\d+\.\s/.test(line)) {
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(12);
+      y = splitAndWriteText(doc, `• ${line.replace(/^(-\s|\d+\.\s)/, '')}`, 18, y, 175, 6);
+      return;
+    }
+
+    const cleanLine = line
+      .replace(/\*\*(.*?)\*\*/g, '$1')
+      .replace(/\*(.*?)\*/g, '$1')
+      .replace(/`(.*?)`/g, '$1');
+
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(12);
+    y = splitAndWriteText(doc, cleanLine, 15, y, 180, 6);
+  });
+
+  return doc.output('blob');
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? '/',
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide in-browser conversion between PDF and Word (`.docx`) so users can export/import documents without server-side processing.
- Preserve formatting and content as much as possible using well-known client-side libraries while keeping the app fully client-side.

### Description
- Add a new `DocumentConverter` UI at `src/components/DocumentConverter.tsx` that supports `PDF → Word` and `Word → PDF` modes with file validation, loading state, and download via `saveAs`.
- Implement conversion utilities in `src/utils/documentConverters.ts`: `convertPdfToWord` extracts text via `pdfjs-dist` and generates DOCX via `docx`, and `convertWordToPdf` converts DOCX to HTML via `mammoth` then renders to PDF with `jspdf`.
- Wire the converter into the main app by adding `DocumentConverter` to `src/App.tsx`, update styles in `src/styles.css`, and add TypeScript shims at `src/types/mammoth.d.ts` and `src/types/pdfjs-dist.d.ts`.
- Update `package.json` to include new dependencies (`docx`, `mammoth`, `pdfjs-dist`) and update `README.md` to document the new features and limitations.

### Testing
- Ran `npm install`, which failed due to environment registry policy (`403 Forbidden`), so dependencies could not be installed (failed).
- Ran `npm run build`, which failed because `vite` and other dependencies were not available due to the failed install (failed).
- Attempted a Playwright-based Chromium screenshot to validate the UI, but the Chromium process crashed in this environment (failed).

Notes: conversion is fully client-side and preserves structure/content to the extent browser libraries allow; very complex layouts or advanced Word features may require manual adjustments after conversion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ba3ff678832599e96789cfac5c89)